### PR TITLE
Add public function to check the vks

### DIFF
--- a/codegen/template/Verifier.sol
+++ b/codegen/template/Verifier.sol
@@ -6,7 +6,7 @@ import "./UncheckedMath.sol";
 contract Verifier is Plonk4VerifierWithAccessToDNext {
     using UncheckedMath for uint256;
 
-    function get_verification_key() internal pure returns(VerificationKey memory vk){
+    function get_verification_key() public pure returns(VerificationKey memory vk) {
         vk.num_inputs = {{num_inputs}};
         vk.domain_size = {{domain_size}};
         vk.omega = {{domain_generator.el}};

--- a/hardhat/contracts/Verifier.sol
+++ b/hardhat/contracts/Verifier.sol
@@ -6,7 +6,7 @@ import "./UncheckedMath.sol";
 contract Verifier is Plonk4VerifierWithAccessToDNext {
     using UncheckedMath for uint256;
 
-    function get_verification_key() internal pure returns(VerificationKey memory vk){
+    function get_verification_key() public pure returns(VerificationKey memory vk) {
         vk.num_inputs = 1;
         vk.domain_size = 256;
         vk.omega = PairingsBn254.new_fr(0x1058a83d529be585820b96ff0a13f2dbd8675a9e5dd2336a6692cc1e5a526c81);


### PR DESCRIPTION
In the server, we want to compare the verification keys on deployed contract and the ones from the config. Add the public getter function to this.