### PR TITLE
ci: Migration from ci-runner to matterlabs-ci-runner

### DIFF
--- a/.github/workflows/solidity_verifier_generator.yml
+++ b/.github/workflows/solidity_verifier_generator.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   generate-solidity-verifier:
-    runs-on: [self-hosted, ci-runner]
+    runs-on: [matterlabs-ci-runner]
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
         with:
@@ -38,7 +38,7 @@ jobs:
           path: ./circuit_limit_${{ matrix.key }}.txt
 
   create-pr:
-    runs-on: [ self-hosted, ci-runner ]
+    runs-on: [ matterlabs-ci-runner ]
     needs: [ "generate-solidity-verifier" ]
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3


### PR DESCRIPTION
Migration from deprecated self-hosted, ci-runners to matterlabs-ci-runners

We are moving from deprecated runners to stable.



## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
